### PR TITLE
Adjusted Blockstorage V3 Snapshot List Endpoint

### DIFF
--- a/openstack/blockstorage/v3/snapshots/urls.go
+++ b/openstack/blockstorage/v3/snapshots/urls.go
@@ -15,7 +15,7 @@ func getURL(c *gophercloud.ServiceClient, id string) string {
 }
 
 func listURL(c *gophercloud.ServiceClient) string {
-	return createURL(c)
+	return c.ServiceURL("snapshots", "detail")
 }
 
 func updateURL(c *gophercloud.ServiceClient, id string) string {


### PR DESCRIPTION
Replaced the normal list snapshots with the detailed list endpoint url.

Fixes #2403

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[https://github.com/gophercloud/gophercloud/blob/master/openstack/blockstorage/v3/snapshots/urls.go](https://github.com/gophercloud/gophercloud/blob/master/openstack/blockstorage/v3/snapshots/urls.go)
